### PR TITLE
[Bugfix] Removed the invalid attributes when passing props

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   ],
   "dependencies": {
     "jquery": "^2.1.4",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1",
     "select2": "^4.0.0",
     "shallow-equal-fuzzy": "^0.0.2"
   },
@@ -47,8 +49,6 @@
     "eslint-config-airbnb": "^4.0.0",
     "eslint-plugin-react": "^3.16.1",
     "extract-text-webpack-plugin": "^1.0.1",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
     "react-hot-loader": "^1.3.0",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.11",

--- a/src/components/Select2.js
+++ b/src/components/Select2.js
@@ -1,4 +1,6 @@
 import React, { Component, PropTypes } from 'react';
+import DOMProperty from 'react/lib/DOMProperty';
+import EventPluginRegistry from 'react/lib/EventPluginRegistry';
 import shallowEqualFuzzy from 'shallow-equal-fuzzy';
 import $ from 'jquery';
 import 'select2';
@@ -136,16 +138,29 @@ export default class Select2 extends Component {
   makeOption(item, k) {
     if (this.isObject(item)) {
       const { id, text, ...itemParams } = item;
-      return (<option key={`option-${k}`} value={id} {...itemParams}>{text}</option>);
+      const filteredAttributes = this.filterAttributes(itemParams);
+      return (<option key={`option-${k}`} value={id} {...filteredAttributes}>{text}</option>);
     }
 
     return (<option key={`option-${k}`} value={item}>{item}</option>);
   }
 
+  filterAttributes(attributes) {
+    let filteredAttributes = {};
+
+    for (const name in attributes) {
+      if (DOMProperty.properties.hasOwnProperty(name) || DOMProperty.isCustomAttribute(name) || EventPluginRegistry.registrationNameModules.hasOwnProperty(name)) {
+        filteredAttributes[name] = attributes[name];
+      }
+    }
+    return filteredAttributes;
+  }
+
   render() {
     const { data, value, ...params } = this.props;
+    const filteredAttributes = this.filterAttributes(params);
     return (
-      <select ref="select" {...params}>
+      <select ref="select" {...filteredAttributes}>
         {data.map((item, k) => {
           if (this.isObject(item) && this.isObject(item.children)) {
             const { children, text, ...itemParams } = item;


### PR DESCRIPTION
Since react@15.2.0, react has started to warn when props that are not DOM attributes are passed through to DOM nodes. I made a function that filters all the valid attributes to avoid this warning
